### PR TITLE
Add: Factory bot for models

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,7 +50,7 @@ group :development, :test do
   gem 'rspec-rails', '~> 7.0.1'
 
   # Factories for reusability of testing data
-  gem "factory_girl_rails", "~> 4.9.0"
+  gem "factory_bot_rails"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,11 +115,11 @@ GEM
     drb (2.2.1)
     error_highlight (0.6.0)
     erubi (1.13.0)
-    factory_girl (4.9.0)
-      activesupport (>= 3.0.0)
-    factory_girl_rails (4.9.0)
-      factory_girl (~> 4.9.0)
-      railties (>= 3.0.0)
+    factory_bot (6.5.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.4.3)
+      factory_bot (~> 6.4)
+      railties (>= 5.0.0)
     ffi (1.17.0-aarch64-linux-gnu)
     ffi (1.17.0-aarch64-linux-musl)
     ffi (1.17.0-arm-linux-gnu)
@@ -373,7 +373,7 @@ DEPENDENCIES
   debug
   devise (~> 4.9)
   error_highlight (>= 0.4.0)
-  factory_girl_rails (~> 4.9.0)
+  factory_bot_rails
   font-awesome-sass (~> 6.5.1)
   importmap-rails
   jbuilder

--- a/config/application.rb
+++ b/config/application.rb
@@ -2,6 +2,8 @@ require_relative "boot"
 
 require "rails/all"
 
+
+
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
@@ -15,6 +17,14 @@ module Ecommerce
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
     config.autoload_lib(ignore: %w[assets tasks])
+
+    config.generators do |g|
+      g.test_framework :rspec,
+      view_specs: false,
+      helper_specs: false,
+      routing_specs: false,
+      request_specs: false
+    end
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,8 @@
+# spec/factories/users.rb
+FactoryBot.define do
+  factory :user do
+    email { "alip2258@test.com" }
+    # sequence(:email) { |n| "tester#{n}@example.com" }
+    password { "741258" }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,21 +1,40 @@
 require 'rails_helper'
 
-RSpec.describe User, type: :model do
+# RSpec.describe User, type: :model do
+#   it "is invalid without an email" do
+#     user = User.new(email: nil)
+#     user.valid?
+#     expect(user.errors[:email]).to include("can't be blank")
+#   end
+
+#   it "is invalid with a duplicate email address" do
+#     User.create(
+#       email: "papo@example.com",
+#       password: "1987595",
+#     )
+#     user = User.new(
+#       email: "papo@example.com",  # Use the same email as the first user
+#       password: "1987875",
+#     )
+#     user.valid?
+#     expect(user.errors[:email]).to include("has already been taken")
+#   end
+# end
+
+describe User do
+  it "has a valid factory" do
+    expect(FactoryBot.build(:user)).to be_valid
+  end
+
   it "is invalid without an email" do
-    user = User.new(email: nil)
+    user = FactoryBot.build(:user, email: nil)
     user.valid?
     expect(user.errors[:email]).to include("can't be blank")
   end
 
   it "is invalid with a duplicate email address" do
-    User.create(
-      email: "papo@example.com",
-      password: "1987595",
-    )
-    user = User.new(
-      email: "papo@example.com",  # Use the same email as the first user
-      password: "1987875",
-    )
+    FactoryBot.create(:user)
+    user = FactoryBot.build(:user)
     user.valid?
     expect(user.errors[:email]).to include("has already been taken")
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,5 +1,6 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
+require_relative './support/factory_bot.rb'
 require 'database_cleaner-active_record'
 ENV['RAILS_ENV'] ||= 'test'
 require_relative '../config/environment'

--- a/spec/support/factory_bot.rb
+++ b/spec/support/factory_bot.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include FactoryBot::Syntax::Methods
+end


### PR DESCRIPTION
# Factory Bot Integration

This pull request integrates Factory Bot into this Rails project for creating test data. Factory Bot is a library for setting up Ruby objects as test data, and it is a replacement for the older Factory Girl library.

## Changes

- Add: factory_bot_rails to the development and test groups.
- Add: Configured RSpec to include Factory Both methods in spec/rails_helper.rb.
- Add: Created a directory spec/factories and added factory definitions for our models.
- Change: Updated our tests to use Factory Bot for creating test data.